### PR TITLE
19/Display repeated timers current run 

### DIFF
--- a/src/app/components/series/run-series/time.tsx
+++ b/src/app/components/series/run-series/time.tsx
@@ -1,0 +1,23 @@
+import { TimeDetails } from "../../util";
+
+interface Props {
+  timeDetails: TimeDetails;
+}
+
+const Time = ({ timeDetails }: Props) => {
+  const { minutes, seconds } = timeDetails;
+
+  let timeString = seconds.toString();
+  if (minutes > 0) {
+    const secondsString = seconds < 10 ? `0${seconds}` : timeString;
+    timeString = `${minutes}:${secondsString}`;
+  }
+
+  return (
+    <div>
+      <div>{timeString}</div>
+    </div>
+  );
+};
+
+export default Time;

--- a/src/app/components/series/single-series.tsx
+++ b/src/app/components/series/single-series.tsx
@@ -17,7 +17,6 @@ const SingleSeries = ({ series, index }: Props) => {
     return acc + curr.interval + mainRepeat;
   }, 0);
   const colour = series.colour as Colour;
-  console.log(totalTime);
 
   const dislayColour = supprtedColours[colour];
   const hoverColour = supprtedHoverColours[colour];

--- a/src/app/components/timers/timer.tsx
+++ b/src/app/components/timers/timer.tsx
@@ -33,6 +33,16 @@ const TimerComponent = ({ timer }: Props) => {
   const position = timer.position;
   const dislayColour = supprtedColours[colour];
 
+  const formatRepititions = (repetitions: number) => {
+    if (repetitions === 1) {
+      return "Once";
+    } else if (repetitions === 2) {
+      return "Twice";
+    } else {
+      return `${repetitions} times`;
+    }
+  };
+
   return (
     <div
       ref={setNodeRef}
@@ -60,7 +70,9 @@ const TimerComponent = ({ timer }: Props) => {
         <div className="text-base-300 text-start font-bold">{name}</div>
         <div>
           <h6 className={`text-base-300 text-sm font-bold text-center`}>
-            {repetitions > 0 ? `Repeat ${repetitions}` : "No Repeat"}
+            {repetitions > 0
+              ? `Repeat ${formatRepititions(repetitions)}`
+              : "No Repeat"}
           </h6>
         </div>
         <div className="flex flex-row justify-end">


### PR DESCRIPTION
Closes #19 

### Description
The timer run state now keeps track of completed timers. This allows repeated timers to display their current run number. For example: 1/2, then 2/2.

Also, when displaying a timers, the string that displays the number of repetitions is now formatted.

Ran `git config core.ignorecase false`.
