### PR TITLE
30/Edit modal uses `modal-top` for mobile view

### DIFF
--- a/src/app/components/series/edit-series/edit-series-modal.tsx
+++ b/src/app/components/series/edit-series/edit-series-modal.tsx
@@ -26,7 +26,7 @@ const EditSeriesModal = ({ id, name, colour }: Props) => {
           <PencilIcon />
         </button>
       </div>
-      <dialog id={modalId} className="modal modal-bottom sm:modal-middle">
+      <dialog id={modalId} className="modal modal-top sm:modal-middle">
         <div className="modal-box">
           <h3 className="font-bold text-lg text-accent">{`Edit ${name}?`}</h3>
           <div className="mt-2">

--- a/src/app/components/timers/edit-timer/edit-timer-modal.tsx
+++ b/src/app/components/timers/edit-timer/edit-timer-modal.tsx
@@ -37,7 +37,7 @@ const EditTimerModal = ({ timer }: Props) => {
           <PencilIcon />
         </button>
       </div>
-      <dialog id={modalId} className="modal modal-bottom sm:modal-middle">
+      <dialog id={modalId} className="modal modal-top sm:modal-middle">
         <div className="modal-box">
           <h3 className="font-bold text-lg text-accent">{`Edit ${name}?`}</h3>
           <div className="mt-2">


### PR DESCRIPTION
Closes #30 

### Description
Edit modals uses the DaisyUI `modal-top` by default. This means mobile views will display edit modals at the top of the page instead of the bottom.