### PR TITLE
35/Timer updates and time display improvements

### DIFF
--- a/src/app/components/series/run-series/interval-timer-view.tsx
+++ b/src/app/components/series/run-series/interval-timer-view.tsx
@@ -6,7 +6,7 @@ import TimerActionButton from "./timer-action-button";
 interface Props {
   name: string;
   isPaused: boolean;
-  mainTimeDetails: ReturnType<typeof getTimeFromSeconds>;
+  mainTimeDetails: ReturnType<typeof getTimeFromSeconds> | "End";
   countTimeDetails: ReturnType<typeof getTimeFromSeconds>;
   mainColour: string;
   onRestart: () => void;
@@ -55,20 +55,35 @@ const IntervalTimerView = ({
         </div>
       </div>
     </div>
-    <div
-      className={`${mainColour} h-[20%] flex flex-col justify-start items-center rounded-b-md`}
-    >
-      <div className="h-full">
-        <div className="mt-1 pb-4">
-          <h5 className="text-lg text-center text-base-300">Next: {name}</h5>
-        </div>
-        <div>
-          <h3 className="text-6xl text-center font-mono text-base-300">
-            <Time timeDetails={mainTimeDetails} />
-          </h3>
+    {typeof mainTimeDetails === "string" ? (
+      <div className="bg-base-200 h-[20%] flex flex-col justify-center items-center rounded-b-md">
+        <div className="h-full">
+          <div className="pb-5" style={{ visibility: "hidden" }}>
+            <h5 className="text-lg text-center text-base-300">Next:</h5>
+          </div>
+          <div>
+            <h3 className="text-6xl text-center font-mono">
+              <div>{mainTimeDetails}</div>
+            </h3>
+          </div>
         </div>
       </div>
-    </div>
+    ) : (
+      <div
+        className={`${mainColour} h-[20%] flex flex-col justify-start items-center rounded-b-md`}
+      >
+        <div className="h-full">
+          <div className="mt-1 pb-4">
+            <h5 className="text-lg text-center text-base-300">Next: {name}</h5>
+          </div>
+          <div>
+            <h3 className="text-6xl text-center font-mono text-base-300">
+              <Time timeDetails={mainTimeDetails} />
+            </h3>
+          </div>
+        </div>
+      </div>
+    )}
   </div>
 );
 

--- a/src/app/components/series/run-series/start-timer-view.tsx
+++ b/src/app/components/series/run-series/start-timer-view.tsx
@@ -1,0 +1,83 @@
+import { CircleArrowIcon, PauseIcon, PlayIcon } from "../../icons";
+import { getTimeFromSeconds } from "../../util";
+import Time from "./time";
+import TimerActionButton from "./timer-action-button";
+
+interface Props {
+  name: string;
+  nextName: string;
+  isPaused: boolean;
+  mainColour: string;
+  countTimeDetails: ReturnType<typeof getTimeFromSeconds>;
+  mainTimeDetails: ReturnType<typeof getTimeFromSeconds>;
+  onRestart: () => void;
+  onPauseResume: () => void;
+}
+
+const StartTimerView = ({
+  name,
+  nextName,
+  isPaused,
+  mainColour,
+  countTimeDetails,
+  mainTimeDetails,
+  onRestart,
+  onPauseResume,
+}: Props) => {
+  return (
+    <div className="flex flex-col grow px-2">
+      <div
+        className={`bg-base-200 h-[80%] w-full flex justify-center items-center rounded-t-md`}
+      >
+        <div className="h-full w-full flex flex-col mx-4">
+          <div className="mt-4">
+            <h5 className="text-xl pb-2 text-center ">Starting in...</h5>
+          </div>
+          <div className="h-full w-full flex flex-col justify-center items-center mb-[15%] md:mb-[50px]">
+            <div className="flex flex-row justify-around w-full">
+              <h1 className="text-9xl text-center w-full  font-mono">
+                <Time timeDetails={countTimeDetails} />
+              </h1>
+            </div>
+            <div className="flex flex-row justify-evenly w-full pt-5 md:w-[550px]">
+              <div className="flex items-center">
+                <TimerActionButton
+                  icon={<CircleArrowIcon size={6} />}
+                  onClick={onRestart}
+                  hoverColour={"bg-base-200"}
+                />
+              </div>
+              <div className="flex items-center">
+                <TimerActionButton
+                  icon={
+                    !isPaused ? <PauseIcon size={6} /> : <PlayIcon size={6} />
+                  }
+                  onClick={onPauseResume}
+                  hoverColour={"bg-base-200"}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className={`${mainColour} h-[20%] flex flex-col justify-start items-center rounded-b-md`}
+      >
+        <div className="h-full">
+          <div className="mt-1 pb-4">
+            <h5 className="text-lg text-center text-base-300">
+              Next: {nextName}
+            </h5>
+          </div>
+          <div>
+            <h3 className="text-6xl text-center font-mono text-base-300">
+              <Time timeDetails={mainTimeDetails} />
+            </h3>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StartTimerView;

--- a/src/app/components/series/single-series.tsx
+++ b/src/app/components/series/single-series.tsx
@@ -1,6 +1,12 @@
 import { Prisma } from "@prisma/client";
 import Link from "next/link";
-import { Colour, supprtedColours, supprtedHoverColours } from "../util";
+import {
+  Colour,
+  formatTime,
+  getTimeFromSeconds,
+  supprtedColours,
+  supprtedHoverColours,
+} from "../util";
 
 interface Props {
   series: Prisma.SeriesGetPayload<{ include: { timers: true } }>;
@@ -21,6 +27,9 @@ const SingleSeries = ({ series, index }: Props) => {
   const dislayColour = supprtedColours[colour];
   const hoverColour = supprtedHoverColours[colour];
 
+  const timeDetails = getTimeFromSeconds(totalTime);
+  const time = formatTime(timeDetails);
+
   return (
     <Link
       className={`flex flex-col ${dislayColour} ${hoverColour} cursor-pointer rounded-md p-2`}
@@ -31,9 +40,7 @@ const SingleSeries = ({ series, index }: Props) => {
       </div>
       <div className="grid grid-cols-3">
         <div className="text-base-300 text-start font-bold">{name}</div>
-        <div className="text-base-300 text-center font-bold">
-          {totalTime} seconds
-        </div>
+        <div className="text-base-300 text-center font-bold">{time}</div>
         <div className="text-base-300 text-end font-bold">
           {timersCount} timers
         </div>

--- a/src/app/components/timers/timer.tsx
+++ b/src/app/components/timers/timer.tsx
@@ -4,7 +4,12 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Timer } from "@prisma/client";
 import { DotSquareIcon } from "../icons";
-import { Colour, supprtedColours } from "../util";
+import {
+  Colour,
+  formatTime,
+  getTimeFromSeconds,
+  supprtedColours,
+} from "../util";
 import DeleteTimerModal from "./delete-timer/delete-timer-modal";
 import EditTimerModal from "./edit-timer/edit-timer-modal";
 
@@ -43,6 +48,11 @@ const TimerComponent = ({ timer, timerCount }: Props) => {
     }
   };
 
+  const maintimeDetails = getTimeFromSeconds(timer.main);
+  const mainTimeDisplay = formatTime(maintimeDetails);
+  const intervalTimeDetails = getTimeFromSeconds(intervalTime);
+  const intervalTimeDisplay = formatTime(intervalTimeDetails);
+
   return (
     <div
       ref={setNodeRef}
@@ -52,7 +62,7 @@ const TimerComponent = ({ timer, timerCount }: Props) => {
       <div className="grid grid-cols-3">
         <div></div>
         <h6 className="text-base-300 text-sm font-bold text-center">
-          {intervalTime > 0 ? `${intervalTime} sec.` : "No Interval"}
+          {intervalTime > 0 ? intervalTimeDisplay : "No Interval"}
         </h6>
         <div className="flex justify-end">
           <div>
@@ -64,7 +74,7 @@ const TimerComponent = ({ timer, timerCount }: Props) => {
         </div>
       </div>
       <div className="text-base-300 text-xl font-bold text-center mt-6 mb-6">
-        <h3>{mainTime} sec.</h3>
+        <h3>{mainTimeDisplay}</h3>
       </div>
       <div className="grid grid-cols-3">
         <div className="text-base-300 text-start font-bold">{name}</div>

--- a/src/app/components/util.ts
+++ b/src/app/components/util.ts
@@ -135,3 +135,16 @@ export const getTimeFromSeconds = (secs: number): TimeDetails => {
     days,
   };
 };
+
+export const formatTime = (time: TimeDetails): string => {
+  const { days, hours, minutes, seconds } = time;
+  if (days > 0) {
+    return `${days}d ${hours}h ${minutes}m ${seconds}s`;
+  } else if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  } else if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  } else {
+    return `${seconds}s`;
+  }
+};

--- a/src/app/hooks/use-countdown.ts
+++ b/src/app/hooks/use-countdown.ts
@@ -21,7 +21,7 @@ export const useCountdown = ({ initialCount }: Props) => {
         }
         return prevTime - 1;
       });
-    }, 500);
+    }, 1000);
   }, []);
 
   // Stop timer

--- a/src/app/hooks/use-countdown.ts
+++ b/src/app/hooks/use-countdown.ts
@@ -21,7 +21,7 @@ export const useCountdown = ({ initialCount }: Props) => {
         }
         return prevTime - 1;
       });
-    }, 1000);
+    }, 500);
   }, []);
 
   // Stop timer


### PR DESCRIPTION
Closes #35 #42 

Changes:
- Modifed the run order of timers. Now plays main timer first then interval.
- Play a 'start' timer before user's timers.
- Display time in separate components. For example: `2h 30m 30s`.